### PR TITLE
Use current script execution path to get relative path

### DIFF
--- a/bin/abspath
+++ b/bin/abspath
@@ -1,1 +1,2 @@
-../src/abspath.sh
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+$DIR/../src/abspath.sh

--- a/bin/abspath
+++ b/bin/abspath
@@ -1,2 +1,2 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-$DIR/../src/abspath.sh
+$DIR/../src/abspath.sh "$@"

--- a/bin/ges
+++ b/bin/ges
@@ -1,1 +1,2 @@
-../src/git-extra-status.sh
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+$DIR/../src/git-extra-status.sh

--- a/bin/ges
+++ b/bin/ges
@@ -1,2 +1,2 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-$DIR/../src/git-extra-status.sh
+$DIR/../src/git-extra-status.sh "$@"

--- a/bin/git-status
+++ b/bin/git-status
@@ -1,1 +1,2 @@
-../src/git-status.sh
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+$DIR/../src/git-status.sh

--- a/bin/git-status
+++ b/bin/git-status
@@ -1,2 +1,2 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-$DIR/../src/git-status.sh
+$DIR/../src/git-status.sh "$@"


### PR DESCRIPTION
When running in my current environment (git bash for Windows) the script 
was failing with the following message:

```sh
$ ges
/c/Users/user-name/git/github/git-extra-status/bin/ges: line 1: 
../src/git-extra-status.sh: No such file or directory
```

This was because the relative path in the running script was being 
inherited from the shell's pwd, not of the script itself.

I also added something to proxy, or forward, args from a executed bin script to the src shell scripts. Without this, I was unable to run `ges *` or `ges repo-name` or anything other than `ges` since the args were being dropped.